### PR TITLE
🐛 Handle start loading animation's completion properly

### DIFF
--- a/Sources/MacaroonUIKit/Screens/Configuration/Loading/BlockingLoadingController.swift
+++ b/Sources/MacaroonUIKit/Screens/Configuration/Loading/BlockingLoadingController.swift
@@ -49,7 +49,7 @@ open class BlockingLoadingController {
             
             switch position {
             case .start:
-                self.updateLoadingIndicatorLayoutWhenLoadingStatusDidChange(loading: false)
+                self.removeLayout()
             case .end:
                 self.loadingIndicator.startAnimating()
                 self.isLoading = true
@@ -71,7 +71,7 @@ open class BlockingLoadingController {
             return
         }
         
-        currentLoadingLayoutAnimator = makeLoadingLayoutAnimator(loading: true)
+        currentLoadingLayoutAnimator = makeLoadingLayoutAnimator(loading: false)
         currentLoadingLayoutAnimator?.addCompletion {
             [weak self] position in
             guard let self = self else { return }


### PR DESCRIPTION
When an animation is stopped by the developer before the start loading
animation has finished, we reverse the start loading animation in
`stopLoading` method, and its completion for .start position will be called as
expected. In that completion method, we should not only deactivate
the constraints of the loading, we should remove the associated layout.